### PR TITLE
fix exclude path pattern in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = [
           type: "asset/source",
         },
         {
-          exclude: /\/esm\//,
+          exclude: /[\\/]esm[\\/]/,
           test: /\.jsx?$/,
           use: {
             loader: "babel-loader",


### PR DESCRIPTION
Windows環境で立ち上げた際に、正しくexclude対象が判別されない問題を修正しました